### PR TITLE
Introduce Common project with shared ErrorLogger utility

### DIFF
--- a/AddFiles/AddFiles.csproj
+++ b/AddFiles/AddFiles.csproj
@@ -186,6 +186,9 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Common</RootNamespace>
+    <AssemblyName>Common</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Helpers\ErrorLogger.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Common/Helpers/ErrorLogger.cs
+++ b/Common/Helpers/ErrorLogger.cs
@@ -1,9 +1,9 @@
 using System;
-using System.IO;
 using System.Diagnostics;
+using System.IO;
 using System.Text;
 
-namespace ImageComparator.Helpers
+namespace Common.Helpers
 {
     /// <summary>
     /// Centralized error logging for diagnostics and debugging
@@ -11,8 +11,7 @@ namespace ImageComparator.Helpers
     public static class ErrorLogger
     {
         private static readonly string LogDirectory = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-            "ImageComparator",
+            AppDomain.CurrentDomain.BaseDirectory,
             "Logs"
         );
 
@@ -43,7 +42,7 @@ namespace ImageComparator.Helpers
             if (ex == null) return;
 
             string message = FormatErrorMessage(context, ex);
-            
+
             // Always write to debug output
             Debug.WriteLine(message);
 
@@ -81,14 +80,14 @@ namespace ImageComparator.Helpers
             sb.AppendLine($"Exception Type: {ex.GetType().FullName}");
             sb.AppendLine($"Message: {ex.Message}");
             sb.AppendLine($"Stack Trace:\n{ex.StackTrace}");
-            
+
             if (ex.InnerException != null)
             {
                 sb.AppendLine($"\nInner Exception: {ex.InnerException.GetType().FullName}");
                 sb.AppendLine($"Inner Message: {ex.InnerException.Message}");
                 sb.AppendLine($"Inner Stack Trace:\n{ex.InnerException.StackTrace}");
             }
-            
+
             sb.AppendLine(new string('-', 80));
             return sb.ToString();
         }
@@ -103,10 +102,10 @@ namespace ImageComparator.Helpers
                 lock (_logLock)
                 {
                     string logFile = Path.Combine(
-                        LogDirectory, 
+                        LogDirectory,
                         $"{logType}_{DateTime.Now:yyyyMMdd}.log"
                     );
-                    
+
                     File.AppendAllText(logFile, message + "\n");
                 }
             }

--- a/Common/Properties/AssemblyInfo.cs
+++ b/Common/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("Common")]
+[assembly: AssemblyDescription("Common utilities for ImageComparator")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Common")]
+[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("b5a6e3a1-7c8d-4e9f-a2b3-c4d5e6f70189")]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Common/Properties/AssemblyInfo.cs
+++ b/Common/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Common")]
-[assembly: AssemblyCopyright("Copyright © 2024")]
+[assembly: AssemblyCopyright("Copyright © 2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -14,5 +14,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("b5a6e3a1-7c8d-4e9f-a2b3-c4d5e6f70189")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/ImageComparator.sln
+++ b/ImageComparator.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageComparator", "ImageCom
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AddFiles", "AddFiles\AddFiles.csproj", "{8A497364-F50F-4E6C-ADB6-5F14A90F23FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,18 @@ Global
 		{8A497364-F50F-4E6C-ADB6-5F14A90F23FF}.Release|x64.Build.0 = Release|x64
 		{8A497364-F50F-4E6C-ADB6-5F14A90F23FF}.Release|x86.ActiveCfg = Release|x86
 		{8A497364-F50F-4E6C-ADB6-5F14A90F23FF}.Release|x86.Build.0 = Release|x86
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Debug|x64.Build.0 = Debug|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Debug|x86.Build.0 = Debug|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Release|x64.ActiveCfg = Release|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Release|x64.Build.0 = Release|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Release|x86.ActiveCfg = Release|Any CPU
+		{B5A6E3A1-7C8D-4E9F-A2B3-C4D5E6F70189}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ImageComparator/Helpers/FileSystemHelper.cs
+++ b/ImageComparator/Helpers/FileSystemHelper.cs
@@ -11,7 +11,7 @@ namespace ImageComparator.Helpers
     /// </summary>
     public static class FileSystemHelper
     {
-        private static readonly string[] AllowedImageExtensions = 
+        private static readonly string[] AllowedImageExtensions =
         {
             ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".ico"
         };
@@ -25,7 +25,7 @@ namespace ImageComparator.Helpers
         {
             string fullPath = null;
             string extension = null;
-            
+
             try
             {
                 // Validate input
@@ -36,7 +36,7 @@ namespace ImageComparator.Helpers
 
                 // Normalize path (prevents traversal attacks)
                 fullPath = Path.GetFullPath(filePath);
-                
+
                 // Get extension early for use in error messages
                 extension = Path.GetExtension(fullPath).ToLowerInvariant();
 
@@ -74,7 +74,7 @@ namespace ImageComparator.Helpers
                         MessageBoxButton.YesNo,
                         MessageBoxImage.Warning
                     );
-                    
+
                     if (result != MessageBoxResult.Yes)
                     {
                         return false;

--- a/ImageComparator/ImageComparator.csproj
+++ b/ImageComparator/ImageComparator.csproj
@@ -192,11 +192,10 @@
     <Compile Include="ClearPopupWindow.xaml.cs">
       <DependentUpon>ClearPopupWindow.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\FileSystemHelper.cs" />
     <Compile Include="HowToUseWindow.xaml.cs">
       <DependentUpon>HowToUseWindow.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Helpers\ErrorLogger.cs" />
-    <Compile Include="Helpers\FileSystemHelper.cs" />
     <Compile Include="LocalizationManager.cs" />
     <Compile Include="Models\AppSettings.cs" />
     <Compile Include="Models\DiscreteCosineTransform2D.cs" />
@@ -378,6 +377,9 @@
       <ProductName>.NET Framework 3.5 SP1</ProductName>
       <Install>false</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ImageComparator/MainWindow.xaml.cs
+++ b/ImageComparator/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using DiscreteCosineTransform;
+﻿using Common.Helpers;
+using DiscreteCosineTransform;
 using ImageComparator.Helpers;
 using ImageComparator.Models;
 using Microsoft.VisualBasic.FileIO;
@@ -678,7 +679,7 @@ namespace ImageComparator
             try
             {
                 string logPath = ErrorLogger.GetCurrentLogPath();
-                
+
                 if (File.Exists(logPath))
                 {
                     System.Diagnostics.Process.Start("notepad.exe", logPath);
@@ -822,13 +823,13 @@ namespace ImageComparator
                 gifMenuItem.IsEnabled = true;
                 tiffMenuItem.IsEnabled = true;
                 icoMenuItem.IsEnabled = true;
-                
+
                 // Enable language menu items (disable the checked one)
                 foreach (var languageMenuItem in languageMenuItems)
                 {
                     languageMenuItem.IsEnabled = !languageMenuItem.IsChecked;
                 }
-                
+
                 includeSubfoldersMenuItem.IsEnabled = true;
                 skipFilesWithDifferentOrientationMenuItem.IsEnabled = true;
                 findExactDuplicatesOnlyMenuItem.IsEnabled = true;
@@ -852,13 +853,13 @@ namespace ImageComparator
                 gifMenuItem.IsEnabled = false;
                 tiffMenuItem.IsEnabled = false;
                 icoMenuItem.IsEnabled = false;
-                
+
                 // Disable all language menu items
                 foreach (var languageMenuItem in languageMenuItems)
                 {
                     languageMenuItem.IsEnabled = false;
                 }
-                
+
                 includeSubfoldersMenuItem.IsEnabled = false;
                 skipFilesWithDifferentOrientationMenuItem.IsEnabled = false;
                 findExactDuplicatesOnlyMenuItem.IsEnabled = false;
@@ -878,16 +879,16 @@ namespace ImageComparator
         {
             // Step 1: Collect files to delete
             var filesToDelete = CollectFilesToDelete();
-            
+
             // Step 2: Delete files from disk and get successfully deleted files
             var deletedFiles = DeleteFilesFromDisk(filesToDelete, out var failedDeletions);
-            
+
             // Step 3: Remove deleted items from lists
             RemoveDeletedItemsFromLists(deletedFiles);
-            
+
             // Step 4: Remove duplicate pairs
             RemoveDuplicatePairs();
-            
+
             // Step 5: Show results to user
             ReportDeletionResults(deletedFiles.Count, filesToDelete.Count, failedDeletions);
         }
@@ -924,8 +925,8 @@ namespace ImageComparator
         /// <returns>True if item should be deleted, false otherwise</returns>
         private bool ShouldDelete(ListViewDataItem item)
         {
-            return deleteMarkedItems 
-                ? item.state == (int)State.MarkedForDeletion 
+            return deleteMarkedItems
+                ? item.state == (int)State.MarkedForDeletion
                 : item.isChecked;
         }
 
@@ -946,10 +947,10 @@ namespace ImageComparator
                 {
                     if (File.Exists(filePath))
                     {
-                        var recycleOption = deletePermanentlyMenuItem.IsChecked 
-                            ? RecycleOption.DeletePermanently 
+                        var recycleOption = deletePermanentlyMenuItem.IsChecked
+                            ? RecycleOption.DeletePermanently
                             : RecycleOption.SendToRecycleBin;
-                        
+
                         FileSystem.DeleteFile(filePath, UIOption.OnlyErrorDialogs, recycleOption);
                         deletedFiles.Add(filePath);
                     }
@@ -980,7 +981,7 @@ namespace ImageComparator
             // Remove from end to avoid index shifting issues
             for (int i = bindingList1.Count - 1; i >= 0; i--)
             {
-                if (deletedFiles.Contains(bindingList1[i].text) || 
+                if (deletedFiles.Contains(bindingList1[i].text) ||
                     deletedFiles.Contains(bindingList2[i].text))
                 {
                     bindingList1.RemoveAt(i);
@@ -1057,16 +1058,16 @@ namespace ImageComparator
             if (failedDeletions.Count > 0)
             {
                 console.Add(LocalizationManager.GetString("Console.DeletionErrors", failedDeletions.Count));
-                
+
                 // Show detailed error message to user for the first few failures
-                var details = string.Join("\n", failedDeletions.Take(5).Select(f => 
+                var details = string.Join("\n", failedDeletions.Take(5).Select(f =>
                     $"  • {Path.GetFileName(f.path)}: {f.error}"));
-                
+
                 if (failedDeletions.Count > 5)
                 {
                     details += $"\n  ... and {failedDeletions.Count - 5} more";
                 }
-                
+
                 MessageBox.Show(
                     LocalizationManager.GetString("Error.DeletionFailed", failedDeletions.Count, details),
                     LocalizationManager.GetString("Error.Title"),
@@ -1784,12 +1785,12 @@ namespace ImageComparator
                     ConsoleMessages = console?.ToList() ?? new List<string>()
                 };
 
-                var options = new JsonSerializerOptions 
-                { 
+                var options = new JsonSerializerOptions
+                {
                     WriteIndented = true,
                     PropertyNameCaseInsensitive = true
                 };
-                
+
                 string jsonString = JsonSerializer.Serialize(settings, options);
                 File.WriteAllText(path, jsonString);
             }
@@ -1815,12 +1816,12 @@ namespace ImageComparator
                 }
 
                 string jsonString = File.ReadAllText(path);
-                
-                var options = new JsonSerializerOptions 
-                { 
-                    PropertyNameCaseInsensitive = true 
+
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
                 };
-                
+
                 var settings = JsonSerializer.Deserialize<AppSettings>(jsonString, options);
 
                 if (settings == null)
@@ -1903,23 +1904,23 @@ namespace ImageComparator
 
                 // Set language based on saved currentLanguageCode with validation
                 string languageToSet = settings.CurrentLanguageCode;
-                
+
                 // List of valid language codes
-                var validLanguages = new[] { 
-                    "en-US", "tr-TR", "ja-JP", "es-ES", "fr-FR", "de-DE", "it-IT", 
-                    "pt-BR", "ru-RU", "zh-CN", "ko-KR", "ar-SA", "fa-IR", "hi-IN", 
-                    "nl-NL", "pl-PL", "sv-SE", "nb-NO", "da-DK" 
+                var validLanguages = new[] {
+                    "en-US", "tr-TR", "ja-JP", "es-ES", "fr-FR", "de-DE", "it-IT",
+                    "pt-BR", "ru-RU", "zh-CN", "ko-KR", "ar-SA", "fa-IR", "hi-IN",
+                    "nl-NL", "pl-PL", "sv-SE", "nb-NO", "da-DK"
                 };
-                
+
                 // Validate and default to en-US if null or invalid
                 if (string.IsNullOrEmpty(languageToSet) || !validLanguages.Contains(languageToSet))
                 {
                     languageToSet = "en-US";
                 }
-                
+
                 // Set menu states for the language
                 SetLanguageMenuStates(languageToSet);
-                
+
                 currentLanguageCode = languageToSet;
                 LocalizationManager.SetLanguage(languageToSet);
                 UpdateUI();
@@ -1935,11 +1936,11 @@ namespace ImageComparator
                 console = new ObservableCollection<string>(settings.ConsoleMessages);
                 files = settings.Files;
                 resolutionArray = settings.ResolutionArray?.Select(s => s.ToSize()).ToArray();
-                
+
                 listView1.ItemsSource = bindingList1;
                 listView2.ItemsSource = bindingList2;
                 outputListView.ItemsSource = console;
-                
+
                 addFolderButton.Visibility = Visibility.Hidden;
                 findDuplicatesButton.Visibility = Visibility.Hidden;
                 clearResultsButton.Visibility = Visibility.Visible;
@@ -2504,10 +2505,10 @@ namespace ImageComparator
 
                 // Serialize to JSON
                 var options = new JsonSerializerOptions { WriteIndented = true };
-                
+
                 string directoriesJson = JsonSerializer.Serialize(directoriesData, options);
                 string filtersJson = JsonSerializer.Serialize(filtersData, options);
-                
+
                 // Write both files - if either fails, both should fail
                 File.WriteAllText(path + @"\Bin\Directories.json", directoriesJson);
                 File.WriteAllText(path + @"\Bin\Filters.json", filtersJson);
@@ -2526,18 +2527,18 @@ namespace ImageComparator
             processStartInfo.RedirectStandardOutput = false;
             processStartInfo.WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden;
             processStartInfo.UseShellExecute = true;
-            
+
             try
             {
                 process = System.Diagnostics.Process.Start(processStartInfo);
                 if (process != null)
                 {
                     process.WaitForExit();
-                    
+
                     // Check for error log files
                     string errorLogFile = path + @"\Bin\AddFiles_Error.log";
                     string tempErrorLog = System.IO.Path.GetTempPath() + "AddFiles_Error.log";
-                    
+
                     if (File.Exists(errorLogFile))
                     {
                         string errorContent = File.ReadAllText(errorLogFile);
@@ -2578,14 +2579,14 @@ namespace ImageComparator
             {
                 ErrorLogger.LogError("AddFiles.exe Start", ex);
             }
-            
+
             ReadFromFile();
         }
 
         private void ReadFromFile()
         {
             string resultsPath = path + @"\Bin\Results.json";
-            
+
             try
             {
                 // Check if file exists before trying to read
@@ -2594,11 +2595,11 @@ namespace ImageComparator
                     ErrorLogger.LogError("ReadFromFile - Results", new FileNotFoundException($"Results.json not found at {resultsPath}. AddFiles.exe may have failed."));
                     return;
                 }
-                
+
                 string jsonString = File.ReadAllText(resultsPath);
                 var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
                 var resultsData = JsonSerializer.Deserialize<ResultsData>(jsonString, options);
-                
+
                 if (resultsData != null)
                 {
                     gotException = resultsData.GotException;
@@ -2607,7 +2608,7 @@ namespace ImageComparator
                         files.AddRange(resultsData.Files);
                     }
                 }
-                
+
                 File.Delete(resultsPath);
             }
             catch (Exception ex)
@@ -2637,7 +2638,7 @@ namespace ImageComparator
                     wrapMode.SetWrapMode(WrapMode.TileFlipXY);
                     graphics.DrawImage(image, destRect, 0, 0, image.Width, image.Height, GraphicsUnit.Pixel, wrapMode);
                 }
-                
+
                 return destImage;
             }
             catch
@@ -2650,7 +2651,7 @@ namespace ImageComparator
         private Bitmap ConvertToGrayscale(Bitmap inputImage)
         {
             Bitmap cloneImage = (Bitmap)inputImage.Clone();
-            
+
             try
             {
                 using (Graphics graphics = Graphics.FromImage(cloneImage))
@@ -2666,7 +2667,7 @@ namespace ImageComparator
                     attributes.SetColorMatrix(colorMatrix);
                     graphics.DrawImage(cloneImage, new Rectangle(0, 0, cloneImage.Width, cloneImage.Height), 0, 0, cloneImage.Width, cloneImage.Height, GraphicsUnit.Pixel, attributes);
                 }
-                
+
                 return cloneImage;
             }
             catch

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ Image Comparator is a WPF-based tool that helps you identify duplicate and simil
 2. Open `ImageComparator.sln` in Visual Studio
 3. Restore NuGet packages
 4. Build the solution (F6 or Build → Build Solution)
-   - This will build both the main ImageComparator project and the AddFiles helper tool
+   - This will build all three projects: ImageComparator (main application), Common (shared utilities), and AddFiles (helper tool)
    - AddFiles.exe is a console application used for file enumeration and will be placed in the `ImageComparator/bin/Debug/Bin/` or `ImageComparator/bin/Release/Bin/` directory
+   - Common.dll provides shared utilities including the ErrorLogger for centralized logging
 5. The main executable will be in `ImageComparator/bin/Debug/` or `ImageComparator/bin/Release/`
 
-**Note**: The AddFiles project is a helper tool that performs file system operations. It must be built along with the main application for the software to function correctly.
+**Note**: The AddFiles project is a helper tool that performs file system operations, and the Common project provides shared utilities used by both ImageComparator and AddFiles. All projects must be built together for the software to function correctly.
 
 ## Usage
 
@@ -172,6 +173,10 @@ ImageComparator/
 │   └── packages.config           # NuGet package references
 ├── AddFiles/                     # Helper console application
 │   ├── Program.cs                # File enumeration tool
+│   └── Properties/               # Assembly info
+├── Common/                       # Shared utilities library
+│   ├── Helpers/                  # Common helper classes
+│   │   └── ErrorLogger.cs        # Centralized error and warning logging
 │   └── Properties/               # Assembly info
 ├── ImageComparator.sln           # Visual Studio solution
 ├── LICENSE.txt                   # GPL v3.0 License


### PR DESCRIPTION
Added Common class library for centralized logging. Moved ErrorLogger to Common.Helpers and updated both ImageComparator and AddFiles to reference and use the shared logger. Removed duplicate ErrorLogger code from ImageComparator. Updated solution and project files accordingly for unified error and warning logging across projects.